### PR TITLE
Update URLs due to Google acquisition and use HTTPS

### DIFF
--- a/Network/Captcha/ReCaptcha.hs
+++ b/Network/Captcha/ReCaptcha.hs
@@ -51,7 +51,7 @@ captchaFields recaptchaPublicKey mbErrorMsg =
               , textarea ! [name "recaptcha_challenge_field", rows "3", cols "40"] << noHtml
               , input ! [thetype "hidden", name "recaptcha_response_field", value "manual_challenge"]
               ]
-  where captchaURL s = "http://api.recaptcha.net/" ++ s ++ "?k=" ++ recaptchaPublicKey ++
+  where captchaURL s = "https://www.google.com/recaptcha/api/" ++ s ++ "?k=" ++ recaptchaPublicKey ++
           case mbErrorMsg of
                Just e  -> "?error=" ++ e
                Nothing -> ""
@@ -63,7 +63,7 @@ validateCaptcha :: String                 -- ^ reCAPTCHA private key
                 -> String                 -- ^ value of the recaptcha_response_field
                 -> IO (Either String ())  -- ^ @Left@ error message, or @Right ()@ for success
 validateCaptcha recaptchaPrivateKey ipaddress challenge response = do
-  let verifyURIString = "http://api-verify.recaptcha.net/verify"
+  let verifyURIString = "http://www.google.com/recaptcha/api/verify"
   let verifyURI = case parseURI verifyURIString of
                        Just uri  -> uri
                        Nothing   -> error $ "Could not parse URI: " ++ verifyURIString


### PR DESCRIPTION
Using HTTPS removes warnings for sites served over https and fixes the module for sites that enforce HSTS. I needed this to get recaptcha to work on my gitit installation (served via https with HSTS).
