### PR TITLE
Clean up recaptcha.cabal

### DIFF
--- a/recaptcha.cabal
+++ b/recaptcha.cabal
@@ -1,7 +1,7 @@
 Name:            recaptcha
 Version:         0.1.0.3
-Cabal-Version:   >= 1.6
-Build-Type:      Custom
+Cabal-Version:   >= 1.8
+Build-Type:      Simple
 License:         BSD3
 License-File:    LICENSE
 Copyright:       (c) 2008 John MacFarlane
@@ -34,5 +34,4 @@ Library
   Hs-Source-Dirs:  .
   Exposed-Modules: Network.Captcha.ReCaptcha
   Ghc-Options:     -Wall
-  Ghc-Prof-Options: -auto-all
 


### PR DESCRIPTION
These are minor cleanups:

- switches to cabal-version:1.8, which allows `cabal` to avoid
  having to fall back into legacy mode (note that for unfortunate
  reasons, Hackage isn't compatible with cabal clients below 1.12
  anymore)

- switch build-type to Simple since this package uses a trivial
  default Setup.hs anyway; so build-type:custom causes unecessary
  overhead for cabal, as it needs to compile, link, and execute an
  external Setup.hs script, rather than simply use its internal
  "Simple" mode.

- remove `ghc-prof-options` which modern cabal versions allow to
  configure externally with package-granularity  via `cabal.project`
  files. Moreover, `cabal check` complained about this.